### PR TITLE
Fix FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,7 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - cargo test --all --no-fail-fast
+    - (cd tokio-trace/test_static_max_level_features && cargo test)
     - cargo doc --all
   i686_test_script:
     - . $HOME/.cargo/env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ members = [
   "tokio-tcp",
   "tokio-tls",
   "tokio-trace",
-  "tokio-trace/test_static_max_level_features",
   "tokio-trace/tokio-trace-core",
   "tokio-udp",
   "tokio-uds",

--- a/tokio-trace/test_static_max_level_features/Cargo.toml
+++ b/tokio-trace/test_static_max_level_features/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "test_cargo_max_level_features"
 version = "0.1.0"


### PR DESCRIPTION
This branch removes the `test_static_max_level_features` crate from the global `tokio` workspace so that running `cargo test --all` doesn't set feature flags for `tokio-trace`, and adds a separate CI step to test that crate on its own.

This should resolve the issue I described in https://github.com/tokio-rs/tokio/pull/987#issuecomment-476334130 and fix the FreeBSD CI build.